### PR TITLE
Fix restoring of Config Files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684218858
+//version: 1689878047
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.21'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -115,6 +115,8 @@ propertyDefaultIfUnset("usesMixinDebug", project.usesMixins)
 propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnset("channel", "stable")
 propertyDefaultIfUnset("mappingsVersion", "12")
+propertyDefaultIfUnset("usesMavenPublishing", true)
+propertyDefaultIfUnset("mavenPublishUrl", "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases")
 propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
@@ -357,7 +359,27 @@ catch (Exception ignored) {
 String identifiedVersion
 String versionOverride = System.getenv("VERSION") ?: null
 try {
-    identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
+    // Produce a version based on the tag, or for branches something like 0.2.2-configurable-maven-and-extras.38+43090270b6-dirty
+    if (versionOverride == null) {
+        def gitDetails = versionDetails()
+        def isDirty = gitVersion().endsWith(".dirty") // No public API for this, isCleanTag has a different meaning
+        String branchName = gitDetails.branchName ?: (System.getenv('GIT_BRANCH') ?: 'git')
+        if (branchName.startsWith('origin/')) {
+            branchName = branchName.minus('origin/')
+        }
+        branchName = branchName.replaceAll("[^a-zA-Z0-9-]+", "-") // sanitize branch names for semver
+        identifiedVersion = gitDetails.lastTag ?: '${gitDetails.gitHash}'
+        if (gitDetails.commitDistance > 0) {
+            identifiedVersion += "-${branchName}.${gitDetails.commitDistance}+${gitDetails.gitHash}"
+            if (isDirty) {
+                identifiedVersion += "-dirty"
+            }
+        } else if (isDirty) {
+            identifiedVersion += "-${branchName}+${gitDetails.gitHash}-dirty"
+        }
+    } else {
+        identifiedVersion = versionOverride
+    }
 }
 catch (Exception ignored) {
     out.style(Style.Failure).text(
@@ -465,8 +487,17 @@ sourceSets {
     }
 }
 
-if (file('addon.gradle').exists()) {
+if (file('addon.gradle.kts').exists()) {
+    apply from: 'addon.gradle.kts'
+} else if (file('addon.gradle').exists()) {
     apply from: 'addon.gradle'
+}
+
+// File for local tweaks not commited to Git
+if (file('addon.local.gradle.kts').exists()) {
+    apply from: 'addon.local.gradle.kts'
+} else if (file('addon.local.gradle').exists()) {
+    apply from: 'addon.local.gradle'
 }
 
 // Allow unsafe repos but warn
@@ -479,7 +510,14 @@ repositories.configureEach { repo ->
     }
 }
 
-apply from: 'repositories.gradle'
+if (file('repositories.gradle.kts').exists()) {
+    apply from: 'repositories.gradle.kts'
+} else if (file('repositories.gradle').exists()) {
+    apply from: 'repositories.gradle'
+} else {
+    logger.error("Neither repositories.gradle.kts nor repositories.gradle was found, make sure you extracted the full ExampleMod template.")
+    throw new RuntimeException("Missing repositories.gradle[.kts]")
+}
 
 configurations {
     runtimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
@@ -585,7 +623,7 @@ dependencies {
         }
     }
     if (usesMixins.toBoolean()) {
-        implementation(mixinProviderSpec)
+        implementation(modUtils.enableMixins(mixinProviderSpec))
     } else if (forceEnableMixins.toBoolean()) {
         runtimeOnlyNonPublishable(mixinProviderSpec)
     }
@@ -611,12 +649,34 @@ configurations.all {
     }
 }
 
-apply from: 'dependencies.gradle'
+dependencies {
+    constraints {
+        def minGtnhLibVersion = "0.0.13"
+        implementation("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+        runtimeOnly("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+        devOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+    }
+}
+
+if (file('dependencies.gradle.kts').exists()) {
+    apply from: 'dependencies.gradle.kts'
+} else if (file('dependencies.gradle').exists()) {
+    apply from: 'dependencies.gradle'
+} else {
+    logger.error("Neither dependencies.gradle.kts nor dependencies.gradle was found, make sure you extracted the full ExampleMod template.")
+    throw new RuntimeException("Missing dependencies.gradle[.kts]")
+}
 
 def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
-def mixinTmpDir = buildDir.path + File.separator + 'tmp' + File.separator + 'mixins'
-def refMap = "${mixinTmpDir}" + File.separator + mixingConfigRefMap
-def mixinSrg = "${mixinTmpDir}" + File.separator + "mixins.srg"
 
 tasks.register('generateAssets') {
     group = "GTNH Buildscript"
@@ -648,46 +708,17 @@ tasks.register('generateAssets') {
 }
 
 if (usesMixins.toBoolean()) {
-    tasks.named("reobfJar", ReobfuscatedJar).configure {
-        extraSrgFiles.from(mixinSrg)
-    }
-
     tasks.named("processResources").configure {
         dependsOn("generateAssets")
     }
 
     tasks.named("compileJava", JavaCompile).configure {
-        doFirst {
-            new File(mixinTmpDir).mkdirs()
-        }
         options.compilerArgs += [
-            "-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}",
-            "-AoutSrgFile=${mixinSrg}",
-            "-AoutRefMapFile=${refMap}",
             // Elan: from what I understand they are just some linter configs so you get some warning on how to properly code
             "-XDenableSunApiLintControl",
             "-XDignore.symbol.file"
         ]
     }
-
-    pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
-        kapt {
-            correctErrorTypes = true
-            javacOptions {
-                option("-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}")
-                option("-AoutSrgFile=$mixinSrg")
-                option("-AoutRefMapFile=$refMap")
-            }
-        }
-        tasks.configureEach { task ->
-            if (task.name == "kaptKotlin") {
-                task.doFirst {
-                    new File(mixinTmpDir).mkdirs()
-                }
-            }
-        }
-    }
-
 }
 
 tasks.named("processResources", ProcessResources).configure {
@@ -705,7 +736,6 @@ tasks.named("processResources", ProcessResources).configure {
     }
 
     if (usesMixins.toBoolean()) {
-        from refMap
         dependsOn("compileJava", "compileScala")
     }
 }
@@ -724,13 +754,13 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.3.5'
+    def lwjgl3ifyVersion = '1.4.0'
     def asmVersion = '9.4'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.19')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -979,6 +1009,9 @@ idea {
                 }
             }
             runConfigurations {
+                "0. Build and Test"(Gradle) {
+                    taskNames = ["build"]
+                }
                 "1. Run Client"(Gradle) {
                     taskNames = ["runClient"]
                 }
@@ -1098,6 +1131,11 @@ tasks.named("processIdeaSettings").configure {
     dependsOn("injectTags")
 }
 
+tasks.named("ideVirtualMainClasses").configure {
+    // Make IntelliJ "Build project" build the mod jars
+    dependsOn("jar", "reobfJar", "spotlessCheck")
+}
+
 // workaround variable hiding in pom processing
 def projectConfigs = project.configurations
 
@@ -1118,12 +1156,14 @@ publishing {
     }
 
     repositories {
-        maven {
-            url = "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases"
-            allowInsecureProtocol = true
-            credentials {
-                username = System.getenv("MAVEN_USER") ?: "NONE"
-                password = System.getenv("MAVEN_PASSWORD") ?: "NONE"
+        if (usesMavenPublishing.toBoolean()) {
+            maven {
+                url = mavenPublishUrl
+                allowInsecureProtocol = mavenPublishUrl.startsWith("http://") // Mostly for the GTNH maven
+                credentials {
+                    username = System.getenv("MAVEN_USER") ?: "NONE"
+                    password = System.getenv("MAVEN_PASSWORD") ?: "NONE"
+                }
             }
         }
     }
@@ -1238,7 +1278,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.1.1"
+def buildscriptGradleVersion = "8.2.1"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion
@@ -1344,8 +1384,14 @@ boolean isNewBuildScriptVersionAvailable() {
 
     String currentBuildScript = getFile("build.gradle").getText()
     String currentBuildScriptHash = getVersionHash(currentBuildScript)
-    String availableBuildScript = availableBuildScriptUrl().newInputStream(parameters).getText()
-    String availableBuildScriptHash = getVersionHash(availableBuildScript)
+    String availableBuildScriptHash
+    try {
+        String availableBuildScript = availableBuildScriptUrl().newInputStream(parameters).getText()
+        availableBuildScriptHash = getVersionHash(availableBuildScript)
+    } catch (IOException e) {
+        logger.warn("Could not check for buildscript update availability: {}", e.message)
+        return false
+    }
 
     boolean isUpToDate = currentBuildScriptHash.empty || availableBuildScriptHash.empty || currentBuildScriptHash == availableBuildScriptHash
     return !isUpToDate
@@ -1509,4 +1555,18 @@ def getSecondaryArtifacts() {
     if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
     if (apiPackage) secondaryArtifacts += [apiJar]
     return secondaryArtifacts
+}
+
+// For easier scripting of things that require variables defined earlier in the buildscript
+if (file('addon.late.gradle.kts').exists()) {
+    apply from: 'addon.late.gradle.kts'
+} else if (file('addon.late.gradle').exists()) {
+    apply from: 'addon.late.gradle'
+}
+
+// File for local tweaks not commited to Git
+if (file('addon.late.local.gradle.kts').exists()) {
+    apply from: 'addon.late.local.gradle.kts'
+} else if (file('addon.late.local.gradle').exists()) {
+    apply from: 'addon.late.local.gradle'
 }

--- a/src/main/java/net/blay09/mods/defaultkeys/CommandDefaultOptions.java
+++ b/src/main/java/net/blay09/mods/defaultkeys/CommandDefaultOptions.java
@@ -1,11 +1,13 @@
 package net.blay09.mods.defaultkeys;
 
+import java.io.File;
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 
 public class CommandDefaultOptions extends CommandBase {
 
@@ -30,33 +32,34 @@ public class CommandDefaultOptions extends CommandBase {
             throw new WrongUsageException(getCommandUsage(sender));
         }
         if (args[0].equals("createUpdateFile")) {
-            sender.addChatMessage(
-                new ChatComponentText("modpack-update file has been created inside the config directory."));
-            sender.addChatMessage(
-                new ChatComponentText(
-                    "You should always ship that file in your modpack; just leave it there forever."));
-            sender.addChatMessage(
-                new ChatComponentText(
-                    "This will ensure that local player configs defined in localconfig.txt will be restored on updates."));
+            try {
+                new File(Minecraft.getMinecraft().mcDataDir, "modpack-update").createNewFile();
+            } catch (Exception e) {
+                sender.addChatMessage(
+                    new ChatComponentTranslation(
+                        "defaultconfigs.cmd.createUpdateFile.failure",
+                        e.getLocalizedMessage()));
+                DefaultKeys.logger.error("Could not create modpack-update file", e);
+                return;
+            }
+            sender.addChatMessage(new ChatComponentTranslation("defaultconfigs.cmd.createUpdateFile.success"));
             return;
         }
         boolean saveOptions = args[0].equals("saveAll") || args[0].equals("saveOptions");
         boolean saveKeys = args[0].equals("saveAll") || args[0].equals("saveKeys");
         if (saveKeys) {
             if (DefaultKeys.instance.saveDefaultMappings()) {
-                sender.addChatMessage(new ChatComponentText("Successfully saved the key configuration."));
+                sender.addChatMessage(new ChatComponentTranslation("defaultconfigs.cmd.saveKeys.success"));
                 DefaultKeys.instance.reloadDefaultMappings();
             } else {
-                sender.addChatMessage(
-                    new ChatComponentText("Failed saving the key configuration. See the log for more information."));
+                sender.addChatMessage(new ChatComponentTranslation("defaultconfigs.cmd.saveKeys.failure"));
             }
         }
         if (saveOptions) {
             if (DefaultKeys.instance.saveDefaultOptions() && DefaultKeys.instance.saveDefaultOptionsOptiFine()) {
-                sender.addChatMessage(new ChatComponentText("Successfully saved the configuration."));
+                sender.addChatMessage(new ChatComponentTranslation("defaultconfigs.cmd.saveOptions.success"));
             } else {
-                sender.addChatMessage(
-                    new ChatComponentText("Failed saving the configuration. See the log for more information."));
+                sender.addChatMessage(new ChatComponentTranslation("defaultconfigs.cmd.saveOptions.failure"));
             }
         }
         if (!saveOptions && !saveKeys) {

--- a/src/main/java/net/blay09/mods/defaultkeys/EventHandler.java
+++ b/src/main/java/net/blay09/mods/defaultkeys/EventHandler.java
@@ -7,6 +7,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -79,10 +80,13 @@ public class EventHandler {
         File modpackUpdate = new File(mcDataDir, "config/modpack-update");
         if (modpackUpdate.exists()) {
             if (restoreLocalConfig()) {
-                // if (!modpackUpdate.delete()) {
-                // logger.error("Could not delete modpack-update file. Delete manually or configs will keep restoring to
-                // this point.");
-                // }
+                try {
+                    Files.delete(modpackUpdate.toPath());
+                } catch (Exception e) {
+                    DefaultKeys.logger.error(
+                        "Could not delete modpack-update file. Delete manually or configs will keep restoring to this point.",
+                        e);
+                }
             }
         } else {
             backupLocalConfig();

--- a/src/main/resources/assets/defaultkeys/lang/en_US.lang
+++ b/src/main/resources/assets/defaultkeys/lang/en_US.lang
@@ -1,0 +1,6 @@
+defaultconfigs.cmd.createUpdateFile.failure=§cCould not create modpack-update file (%1$s)
+defaultconfigs.cmd.createUpdateFile.success=§amodpack-update file has been created inside the config directory. You should always ship that file in your modpack; just leave it there forever. This will ensure that local player configs defined in localconfig.txt will be restored on updates.
+defaultconfigs.cmd.saveKeys.failure=§cFailed saving the key configuration. See the log for more information.
+defaultconfigs.cmd.saveKeys.success=§aSuccessfully saved the key configuration.
+defaultconfigs.cmd.saveOptions.failure=§cFailed saving the configuration. See the log for more information.
+defaultconfigs.cmd.saveOptions.success=§aSuccessfully saved the configuration.


### PR DESCRIPTION
Previously, if the `./config/modpack-update` file was shipped with a pack, it wouldn't have been deleted. This would've triggered the `restoreLocalConfig()` method each time instead of only once after the update and `backupLocalConfig()` every following start. The code responsible for this was commented out. I uncommented it and tested it (using Technic Solder) and couldn't find any issues.

Allows https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/13971 to work.

Other improvements:
- Made command responses translatable
- Replaced `java.io.File#delete()` with `java.nio.Files#delete(java.nio.Path)` in a `try-catch`-block to be able to log the reason should the deletion fail.
- Fixed `/defaultconfigs createUpdateFile` command
- Updated buildscript